### PR TITLE
Implement node-specific build settings with inheritance

### DIFF
--- a/cmake_node_editor/creation_dialog.py
+++ b/cmake_node_editor/creation_dialog.py
@@ -4,7 +4,7 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
     QDialog, QLabel, QLineEdit, QPushButton, QVBoxLayout, QHBoxLayout,
     QFormLayout, QWidget, QFileDialog, QMessageBox, QDialogButtonBox,
-    QScrollArea
+    QScrollArea, QCheckBox, QComboBox
 )
 
 class NodeCreationDialog(QDialog):
@@ -14,8 +14,9 @@ class NodeCreationDialog(QDialog):
       - Multiple CMake options
       - A target project folder (containing a CMakeLists.txt)
     """
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, existing_nodes=None):
         super().__init__(parent)
+        self.existing_nodes = existing_nodes if existing_nodes else []
         self.setWindowTitle("Create New Node")
         self.resize(500, 350)
 
@@ -23,6 +24,15 @@ class NodeCreationDialog(QDialog):
         self.node_name_edit = QLineEdit()
         self.node_options_layout = QVBoxLayout()
         self.option_rows = []
+
+        # Inheritance options
+        self.inherit_combo = QComboBox()
+        self.inherit_combo.addItem("None")
+        for n in self.existing_nodes:
+            self.inherit_combo.addItem(n.title())
+        self.chk_inherit_proj = QCheckBox("Project Path")
+        self.chk_inherit_opts = QCheckBox("CMake Options")
+        self.chk_inherit_build = QCheckBox("Build Settings")
 
         # Project path
         self.project_path_edit = QLineEdit()
@@ -34,11 +44,17 @@ class NodeCreationDialog(QDialog):
 
         # "Add Option" button
         self.btn_add_option = QPushButton("Add CMake Option")
-        self.btn_add_option.clicked.connect(self.addOptionEdit)
+        self.btn_add_option.clicked.connect(lambda: self.addOptionEdit())
 
         # Build a form layout
         form = QFormLayout()
         form.addRow("Node Name:", self.node_name_edit)
+        form.addRow("Inherit From:", self.inherit_combo)
+        inherit_layout = QHBoxLayout()
+        inherit_layout.addWidget(self.chk_inherit_proj)
+        inherit_layout.addWidget(self.chk_inherit_opts)
+        inherit_layout.addWidget(self.chk_inherit_build)
+        form.addRow("Copy Options:", inherit_layout)
 
         # Row for project path + browse button
         proj_path_layout = QHBoxLayout()
@@ -109,20 +125,22 @@ class NodeCreationDialog(QDialog):
         When user clicks OK, ensure the project folder is valid and has CMakeLists.txt.
         """
         proj_path = self.project_path_edit.text().strip()
-        if not os.path.isdir(proj_path):
-            QMessageBox.critical(self, "Error", "Please select a valid project folder.")
-            return
+        inherit_proj = self.chk_inherit_proj.isChecked() and self.inherit_combo.currentIndex() > 0
+        if not inherit_proj:
+            if not os.path.isdir(proj_path):
+                QMessageBox.critical(self, "Error", "Please select a valid project folder.")
+                return
 
-        cmakelists_file = os.path.join(proj_path, "CMakeLists.txt")
-        if not os.path.exists(cmakelists_file):
-            QMessageBox.critical(self, "Error", "No CMakeLists.txt found in that folder.")
-            return
+            cmakelists_file = os.path.join(proj_path, "CMakeLists.txt")
+            if not os.path.exists(cmakelists_file):
+                QMessageBox.critical(self, "Error", "No CMakeLists.txt found in that folder.")
+                return
 
         self.accept()
 
     def getNodeData(self):
         """
-        Return (node_name, cmake_options, project_path) as a tuple.
+        Return (node_name, cmake_options, project_path, inherit_index, inherit_flags) as a tuple.
         node_name  : str
         cmake_opts : list of str
         proj_path  : str
@@ -134,4 +152,10 @@ class NodeCreationDialog(QDialog):
             if val:
                 cmake_opts.append(val)
         proj_path = self.project_path_edit.text().strip()
-        return node_name, cmake_opts, proj_path
+        inherit_index = self.inherit_combo.currentIndex() - 1
+        flags = {
+            "project": self.chk_inherit_proj.isChecked(),
+            "options": self.chk_inherit_opts.isChecked(),
+            "build": self.chk_inherit_build.isChecked(),
+        }
+        return node_name, cmake_opts, proj_path, inherit_index, flags

--- a/cmake_node_editor/datas.py
+++ b/cmake_node_editor/datas.py
@@ -2,33 +2,35 @@ from dataclasses import dataclass, is_dataclass, asdict, field
 from PyQt6.QtWidgets import QGraphicsPathItem
 import json
 
+
+@dataclass
+class BuildSettings:
+    build_dir: str
+    install_dir: str
+    build_type: str
+    prefix_path: str
+    toolchain_file: str
+    generator: str
+    c_compiler: str = ""
+    cxx_compiler: str = ""
+
 @dataclass
 class NodeData:
-    node_id : int
-    title : str
-    pos_x : float
-    pos_y : float
-    cmake_options : list[str]
-    project_path : str
-    code_before_build : str = ""
-    code_after_install : str = ""
+    node_id: int
+    title: str
+    pos_x: float
+    pos_y: float
+    cmake_options: list[str]
+    project_path: str
+    build_settings: BuildSettings
+    code_before_build: str = ""
+    code_after_install: str = ""
 
 @dataclass
 class EdgeData:
     source_node_id : int
     target_node_id : int
 
-@dataclass
-class GlobalConfigData:
-    build_dir : str
-    install_dir : str
-    build_type : str
-    prefix_path : str
-    toolchain_file : str
-    generator: str
-    start_node_id : int
-    c_compiler: str = ""
-    cxx_compiler: str = ""
 
 @dataclass
 class CommandData:
@@ -38,14 +40,14 @@ class CommandData:
 
 @dataclass
 class NodeCommands:
-    index : int
-    node_data : NodeData
-    cmd_list : list[CommandData] = field(default_factory=list)
+    index: int
+    node_data: NodeData
+    cmd_list: list[CommandData] = field(default_factory=list)
 
 @dataclass
 class ProjectCommands:
-    global_config_data : GlobalConfigData
-    node_commands_list : list[NodeCommands] = field(default_factory=list)
+    start_node_id: int
+    node_commands_list: list[NodeCommands] = field(default_factory=list)
 
 @dataclass
 class SubprocessResponseData:

--- a/cmake_node_editor/node_editor_window.py
+++ b/cmake_node_editor/node_editor_window.py
@@ -13,7 +13,7 @@ from PyQt6.QtWidgets import (
 from .node_scene import NodeScene, NodeItem
 from .datas import (
     ProjectCommands, NodeCommands, CommandData,
-    GlobalConfigData, SubprocessLogData, SubprocessResponseData
+    BuildSettings, SubprocessLogData, SubprocessResponseData
 )
 from .creation_dialog import NodeCreationDialog
 from .worker import worker_main
@@ -117,14 +117,13 @@ class NodeEditorWindow(QMainWindow):
         self.setCentralWidget(self.view)
 
         # Prepare dock widgets
+
         self.initBuildOutputDock()
         self.initPropertiesDock()
-        self.initGlobalBuildDock()
         self.initTopologyDock()
 
         # Setup other UI pieces
         self.initNodePropertiesUI()
-        self.initGlobalBuildUI()
         self.initMenu()
 
         # Connect scene signals
@@ -170,16 +169,8 @@ class NodeEditorWindow(QMainWindow):
 
         self.dock_properties.setWidget(self.properties_scroll)
         self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self.dock_properties)
+        self.dock_properties.hide()
 
-    def initGlobalBuildDock(self):
-        """
-        Dock for global build settings.
-        """
-        self.dock_build = QDockWidget("Global Build Settings", self)
-        self.build_widget = QWidget()
-        self.build_layout = QFormLayout(self.build_widget)
-        self.dock_build.setWidget(self.build_widget)
-        self.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, self.dock_build)
 
     def initTopologyDock(self):
         """
@@ -240,18 +231,10 @@ class NodeEditorWindow(QMainWindow):
             return
 
         global_cfg = {
-            "build_dir": self.edit_build_dir.text().strip(),
-            "install_dir": self.edit_install_dir.text().strip(),
-            "build_type": self.combo_build_type.currentText(),
-            "prefix_path": self.edit_prefix_path.text().strip(),
-            "toolchain": self.edit_toolchain.text().strip(),
-            "generator": self.combo_generator.currentText(),
-            "start_node_id": self.edit_start_node_id.text().strip(),
-            "c_compiler": self.edit_c_compiler.text().strip(),
-            "cxx_compiler": self.edit_cxx_compiler.text().strip()
+            "start_node_id": self.edit_start_node_id.text().strip()
         }
 
-        self.scene.saveProjectToJson(filepath, global_cfg)
+        self.scene.saveProjectToJson(filepath, global_cfg.get("start_node_id"))
         QMessageBox.information(self, "Info", "Project has been saved!")
 
     def onLoadProject(self):
@@ -271,74 +254,8 @@ class NodeEditorWindow(QMainWindow):
         """
         Restore global build settings from the loaded dict.
         """
-        self.edit_build_dir.setText(global_cfg.get("build_dir", os.path.join(os.getcwd(), "build")))
-        self.edit_install_dir.setText(global_cfg.get("install_dir", os.path.join(os.getcwd(), "install")))
-
-        build_type = global_cfg.get("build_type", "Debug")
-        idx = self.combo_build_type.findText(build_type)
-        if idx >= 0:
-            self.combo_build_type.setCurrentIndex(idx)
-        else:
-            self.combo_build_type.setCurrentText(build_type)
-
-        self.edit_prefix_path.setText(global_cfg.get("prefix_path", os.path.join(os.getcwd(), "install")))
-        self.edit_toolchain.setText(global_cfg.get("toolchain", ""))
-
-        gen = global_cfg.get("generator", "Default (not specified)")
-        idx_gen = self.combo_generator.findText(gen)
-        if idx_gen >= 0:
-            self.combo_generator.setCurrentIndex(idx_gen)
-        else:
-            self.combo_generator.setCurrentText(gen)
-
         self.edit_start_node_id.setText(global_cfg.get("start_node_id", ""))
-        self.edit_c_compiler.setText(global_cfg.get("c_compiler", ""))
-        self.edit_cxx_compiler.setText(global_cfg.get("cxx_compiler", ""))
 
-    # ----------------------------------------------------------------
-    # Global build settings UI
-    # ----------------------------------------------------------------
-    def initGlobalBuildUI(self):
-        """
-        Setup controls for global build settings in self.build_layout
-        """
-        self.edit_build_dir = QLineEdit(os.path.join(os.getcwd(), "build"))
-        self.build_layout.addRow("Build Directory:", self.edit_build_dir)
-
-        self.combo_build_type = QComboBox()
-        self.combo_build_type.addItems(["Debug", "Release", "RelWithDebInfo", "MinSizeRel"])
-        self.build_layout.addRow("Build Type:", self.combo_build_type)
-
-        self.edit_install_dir = QLineEdit(os.path.join(os.getcwd(), "install"))
-        self.build_layout.addRow("Install Directory:", self.edit_install_dir)
-
-        self.edit_prefix_path = QLineEdit(os.path.join(os.getcwd(), "install"))
-        self.build_layout.addRow("PREFIX_PATH:", self.edit_prefix_path)
-
-        self.edit_toolchain = QLineEdit()
-        self.build_layout.addRow("Toolchain File:", self.edit_toolchain)
-
-        self.combo_generator = QComboBox()
-        self.combo_generator.addItem("Default (not specified)")
-        self.combo_generator.addItems([
-            "Visual Studio 17 2022", "Visual Studio 16 2019", 
-            "Ninja", "Unix Makefiles", 
-            # ... etc ...
-        ])
-        self.build_layout.addRow("CMake Generator:", self.combo_generator)
-        
-        self.edit_c_compiler = QLineEdit()
-        self.build_layout.addRow("C Compiler (CMAKE_C_COMPILER):", self.edit_c_compiler)
-
-        self.edit_cxx_compiler = QLineEdit()
-        self.build_layout.addRow("C++ Compiler (CMAKE_CXX_COMPILER):", self.edit_cxx_compiler)
-
-        self.edit_start_node_id = QLineEdit()
-        self.build_layout.addRow("Start Node ID:", self.edit_start_node_id)
-
-        self.btn_build_all = QPushButton("Start Build")
-        self.btn_build_all.clicked.connect(self.onBuildAll)
-        self.build_layout.addWidget(self.btn_build_all)
 
     # ----------------------------------------------------------------
     # Node Properties UI
@@ -382,6 +299,40 @@ class NodeEditorWindow(QMainWindow):
 
         self.properties_layout.addWidget(option_scroll)
 
+        # Build settings
+        form_build = QFormLayout()
+        self.edit_build_dir = QLineEdit(os.path.join(os.getcwd(), "build"))
+        form_build.addRow("Build Directory:", self.edit_build_dir)
+
+        self.combo_build_type = QComboBox()
+        self.combo_build_type.addItems(["Debug", "Release", "RelWithDebInfo", "MinSizeRel"])
+        form_build.addRow("Build Type:", self.combo_build_type)
+
+        self.edit_install_dir = QLineEdit(os.path.join(os.getcwd(), "install"))
+        form_build.addRow("Install Directory:", self.edit_install_dir)
+
+        self.edit_prefix_path = QLineEdit(os.path.join(os.getcwd(), "install"))
+        form_build.addRow("PREFIX_PATH:", self.edit_prefix_path)
+
+        self.edit_toolchain = QLineEdit()
+        form_build.addRow("Toolchain File:", self.edit_toolchain)
+
+        self.combo_generator = QComboBox()
+        self.combo_generator.addItem("Default (not specified)")
+        self.combo_generator.addItems([
+            "Visual Studio 17 2022", "Visual Studio 16 2019",
+            "Ninja", "Unix Makefiles",
+        ])
+        form_build.addRow("CMake Generator:", self.combo_generator)
+
+        self.edit_c_compiler = QLineEdit()
+        form_build.addRow("C Compiler:", self.edit_c_compiler)
+
+        self.edit_cxx_compiler = QLineEdit()
+        form_build.addRow("C++ Compiler:", self.edit_cxx_compiler)
+
+        self.properties_layout.addLayout(form_build)
+
         self.properties_layout.addWidget(QLabel("Pre-Build Script (py_code_before_build):"))
         self.edit_py_before = QPlainTextEdit()
         self.properties_layout.addWidget(self.edit_py_before)
@@ -389,6 +340,15 @@ class NodeEditorWindow(QMainWindow):
         self.properties_layout.addWidget(QLabel("Post-Install Script (py_code_after_install):"))
         self.edit_py_after = QPlainTextEdit()
         self.properties_layout.addWidget(self.edit_py_after)
+
+        form_misc = QFormLayout()
+        self.edit_start_node_id = QLineEdit()
+        form_misc.addRow("Start Node ID:", self.edit_start_node_id)
+        self.properties_layout.addLayout(form_misc)
+
+        self.btn_build_all = QPushButton("Start Build")
+        self.btn_build_all.clicked.connect(self.onBuildAll)
+        self.properties_layout.addWidget(self.btn_build_all)
 
         self.btn_apply_properties = QPushButton("Apply Node Properties")
         self.btn_apply_properties.clicked.connect(self.onApplyNodeProperties)
@@ -431,15 +391,31 @@ class NodeEditorWindow(QMainWindow):
     # Node operations
     # ----------------------------------------------------------------
     def onAddNodeDialog(self):
-        dlg = NodeCreationDialog(self)
+        dlg = NodeCreationDialog(self, existing_nodes=self.scene.nodes)
         if dlg.exec() == dlg.DialogCode.Accepted:
-            node_name, opts, proj_path = dlg.getNodeData()
+            node_name, opts, proj_path, inherit_idx, flags = dlg.getNodeData()
+            if inherit_idx >= 0 and inherit_idx < len(self.scene.nodes):
+                base_node = self.scene.nodes[inherit_idx]
+            else:
+                base_node = None
+            if base_node:
+                if flags.get("project"):
+                    proj_path = base_node.projectPath()
+                if flags.get("options"):
+                    opts = list(base_node.cmakeOptions())
+                if flags.get("build"):
+                    bs = base_node.buildSettings()
+                else:
+                    bs = None
+            else:
+                bs = None
+
             if not node_name:
                 node_name = f"Node_{self.scene.nodeCounter}"
             if any(n.title() == node_name for n in self.scene.nodes):
                 QMessageBox.warning(self, "Warning", f"Node name '{node_name}' already exists.")
                 return
-            new_node = self.scene.addNewNode(node_name, opts, proj_path)
+            new_node = self.scene.addNewNode(node_name, opts, proj_path, bs)
             self.scene.clearSelection()
             new_node.setSelected(True)
 
@@ -454,9 +430,11 @@ class NodeEditorWindow(QMainWindow):
         if sel_items and isinstance(sel_items[0], NodeItem):
             self.current_node = sel_items[0]
             self.updatePropertiesPanelFromNode()
+            self.dock_properties.show()
         else:
             self.current_node = None
             self.clearPropertiesPanel()
+            self.dock_properties.hide()
 
     def clearPropertiesPanel(self):
         self.edit_node_name.clear()
@@ -465,6 +443,14 @@ class NodeEditorWindow(QMainWindow):
             self.cmake_option_layout.removeWidget(row_w)
             row_w.deleteLater()
         self.cmake_option_rows = []
+        self.edit_build_dir.clear()
+        self.edit_install_dir.clear()
+        self.edit_prefix_path.clear()
+        self.edit_toolchain.clear()
+        self.edit_c_compiler.clear()
+        self.edit_cxx_compiler.clear()
+        self.edit_py_before.clear()
+        self.edit_py_after.clear()
 
     def updatePropertiesPanelFromNode(self):
         if not self.current_node:
@@ -479,7 +465,25 @@ class NodeEditorWindow(QMainWindow):
             row_widget, line_edit = self.createOptionRow(opt)
             self.cmake_option_rows.append((row_widget, line_edit))
             self.cmake_option_layout.insertWidget(len(self.cmake_option_rows)-1, row_widget)
-            
+
+        bs = self.current_node.buildSettings()
+        self.edit_build_dir.setText(bs.build_dir)
+        idx_bt = self.combo_build_type.findText(bs.build_type)
+        if idx_bt >= 0:
+            self.combo_build_type.setCurrentIndex(idx_bt)
+        else:
+            self.combo_build_type.setCurrentText(bs.build_type)
+        self.edit_install_dir.setText(bs.install_dir)
+        self.edit_prefix_path.setText(bs.prefix_path)
+        self.edit_toolchain.setText(bs.toolchain_file)
+        gen_idx = self.combo_generator.findText(bs.generator)
+        if gen_idx >= 0:
+            self.combo_generator.setCurrentIndex(gen_idx)
+        else:
+            self.combo_generator.setCurrentText(bs.generator)
+        self.edit_c_compiler.setText(bs.c_compiler)
+        self.edit_cxx_compiler.setText(bs.cxx_compiler)
+
         self.edit_py_before.setPlainText(self.current_node.codeBeforeBuild())
         self.edit_py_after.setPlainText(self.current_node.codeAfterInstall())
 
@@ -505,6 +509,18 @@ class NodeEditorWindow(QMainWindow):
 
         new_proj_path = self.edit_node_project_path.text().strip()
         self.current_node.setProjectPath(new_proj_path)
+
+        bs = BuildSettings(
+            build_dir=self.edit_build_dir.text().strip(),
+            install_dir=self.edit_install_dir.text().strip(),
+            build_type=self.combo_build_type.currentText(),
+            prefix_path=self.edit_prefix_path.text().strip(),
+            toolchain_file=self.edit_toolchain.text().strip(),
+            generator=self.combo_generator.currentText(),
+            c_compiler=self.edit_c_compiler.text().strip(),
+            cxx_compiler=self.edit_cxx_compiler.text().strip(),
+        )
+        self.current_node.setBuildSettings(bs)
 
         self.current_node.setCodeBeforeBuild(self.edit_py_before.toPlainText())
         self.current_node.setCodeAfterInstall(self.edit_py_after.toPlainText())
@@ -532,26 +548,12 @@ class NodeEditorWindow(QMainWindow):
         """
         self.build_output_text.clear()
 
-        # Global config
-        build_root    = self.edit_build_dir.text().strip()
-        install_root  = self.edit_install_dir.text().strip()
-        build_type    = self.combo_build_type.currentText()
-        toolchain_path= self.edit_toolchain.text().strip()
-        prefix_path   = self.edit_prefix_path.text().strip()
-        c_compiler    = self.edit_c_compiler.text().strip()
-        cxx_compiler  = self.edit_cxx_compiler.text().strip() 
-
-        generator = self.combo_generator.currentText()
-        if generator.startswith("Default"):
-            generator = ""
-
         # Topological sort
         sorted_nodes = self.scene.topologicalSort()
         if sorted_nodes is None:
             QMessageBox.critical(self, "Error", "Detected circular dependency, cannot build.")
             return
 
-        start_node_id_str = self.edit_start_node_id.text().strip()
         start_id = None
         start_index = 0
         if start_node_id_str:
@@ -567,27 +569,24 @@ class NodeEditorWindow(QMainWindow):
             except ValueError:
                 QMessageBox.warning(self, "Warning", f"Start Node ID '{start_node_id_str}' invalid, building from beginning.")
 
-        # Build the ProjectCommands
-        global_cfg_data = GlobalConfigData(
-            build_dir=build_root,
-            install_dir=install_root,
-            build_type=build_type,
-            prefix_path=prefix_path,
-            toolchain_file=toolchain_path,
-            generator=generator,
-            start_node_id=start_id if start_id is not None else -1,
-            c_compiler=c_compiler,
-            cxx_compiler=cxx_compiler
-        )
-
         project_commands = ProjectCommands(
-            global_config_data = global_cfg_data,
-            node_commands_list = []
+            start_node_id=start_id if start_id is not None else -1,
+            node_commands_list=[]
         )
 
         # For each node in sorted order, build NodeCommands & CommandData
         for node_obj in sorted_nodes[start_index:]:
             node_cmd = NodeCommands(index=node_obj.id(), node_data=node_obj.nodeData(), cmd_list=[])
+
+            bs = node_obj.buildSettings()
+            build_root = bs.build_dir
+            install_root = bs.install_dir
+            build_type = bs.build_type
+            toolchain_path = bs.toolchain_file
+            prefix_path = bs.prefix_path
+            generator = bs.generator
+            c_compiler = bs.c_compiler
+            cxx_compiler = bs.cxx_compiler
 
             # Pre-build script
             if node_obj.codeBeforeBuild().strip():
@@ -624,10 +623,10 @@ class NodeEditorWindow(QMainWindow):
             ]
             if generator:
                 cmd_configure[1:1] = ["-G", generator]
-            if global_cfg_data.c_compiler:
-                cmd_configure.append(f"-DCMAKE_C_COMPILER:FILEPATH={global_cfg_data.c_compiler}")
-            if global_cfg_data.cxx_compiler:
-                cmd_configure.append(f"-DCMAKE_CXX_COMPILER:FILEPATH={global_cfg_data.cxx_compiler}")
+            if c_compiler:
+                cmd_configure.append(f"-DCMAKE_C_COMPILER:FILEPATH={c_compiler}")
+            if cxx_compiler:
+                cmd_configure.append(f"-DCMAKE_CXX_COMPILER:FILEPATH={cxx_compiler}")
             if toolchain_path:
                 cmd_configure.append(f"-DCMAKE_TOOLCHAIN_FILE={toolchain_path}")
             if prefix_path:

--- a/cmake_node_editor/node_scene.py
+++ b/cmake_node_editor/node_scene.py
@@ -10,7 +10,8 @@ from PyQt6.QtWidgets import (
 )
 
 from dataclasses import asdict
-from .datas import NodeData, EdgeData
+import os
+from .datas import NodeData, EdgeData, BuildSettings
 
 
 class Pin(QGraphicsRectItem):
@@ -178,6 +179,14 @@ class NodeItem(QGraphicsRectItem):
         # Initialize NodeData
         if data is None:
             # If no NodeData was provided, create one
+            default_bs = BuildSettings(
+                build_dir=os.path.join(os.getcwd(), "build"),
+                install_dir=os.path.join(os.getcwd(), "install"),
+                build_type="Debug",
+                prefix_path=os.path.join(os.getcwd(), "install"),
+                toolchain_file="",
+                generator="",
+            )
             self._data = NodeData(
                 node_id=node_id,
                 title=title,
@@ -185,6 +194,7 @@ class NodeItem(QGraphicsRectItem):
                 pos_y=0,
                 cmake_options=cmake_options if cmake_options else [],
                 project_path=project_path,
+                build_settings=default_bs,
                 code_before_build="",
                 code_after_install=""
             )
@@ -289,6 +299,12 @@ class NodeItem(QGraphicsRectItem):
     def projectPath(self):
         return self._data.project_path
 
+    def buildSettings(self) -> BuildSettings:
+        return self._data.build_settings
+
+    def setBuildSettings(self, bs: BuildSettings):
+        self._data.build_settings = bs
+
     def codeBeforeBuild(self):
         return self._data.code_before_build
 
@@ -331,16 +347,28 @@ class NodeScene(QGraphicsScene):
         if self.topology_changed_callback:
             self.topology_changed_callback()
 
-    def addNewNode(self, title, cmake_options, project_path):
+    def addNewNode(self, title, cmake_options, project_path, build_settings=None):
         """
         Create a new NodeItem, place it in the scene, and update topology.
         """
         node_id = NodeScene.nodeCounter
         NodeScene.nodeCounter += 1
-        new_node = NodeItem(node_id=node_id, 
+        if build_settings is None:
+            build_settings = BuildSettings(
+                build_dir=os.path.join(os.getcwd(), "build"),
+                install_dir=os.path.join(os.getcwd(), "install"),
+                build_type="Debug",
+                prefix_path=os.path.join(os.getcwd(), "install"),
+                toolchain_file="",
+                generator="",
+            )
+        new_node = NodeItem(node_id=node_id,
                             title=title,
-                            cmake_options=cmake_options, 
-                            project_path=project_path)
+                            cmake_options=cmake_options,
+                            project_path=project_path,
+                            data=None)
+        # Override build settings
+        new_node.setBuildSettings(build_settings)
         new_node.setPos(100, 100)
         new_node.nodeData().pos_x = 100
         new_node.nodeData().pos_y = 100
@@ -430,7 +458,7 @@ class NodeScene(QGraphicsScene):
             return None
         return result
 
-    def saveProjectToJson(self, filepath, global_config=None):
+    def saveProjectToJson(self, filepath, start_node_id=None):
         """
         Save this scene to a JSON file.
         Includes:
@@ -439,7 +467,7 @@ class NodeScene(QGraphicsScene):
          - edge data
         """
         data = {
-            "global": global_config if global_config else {},
+            "global": {"start_node_id": start_node_id} if start_node_id is not None else {},
             "nodes": [],
             "edges": []
         }
@@ -478,7 +506,28 @@ class NodeScene(QGraphicsScene):
         node_map = {}
         # Recreate nodes
         for nd in data.get("nodes", []):
-            node_data = NodeData(**nd)
+            bs_dict = nd.get("build_settings", {})
+            bs = BuildSettings(
+                build_dir=bs_dict.get("build_dir", os.path.join(os.getcwd(), "build")),
+                install_dir=bs_dict.get("install_dir", os.path.join(os.getcwd(), "install")),
+                build_type=bs_dict.get("build_type", "Debug"),
+                prefix_path=bs_dict.get("prefix_path", os.path.join(os.getcwd(), "install")),
+                toolchain_file=bs_dict.get("toolchain_file", ""),
+                generator=bs_dict.get("generator", ""),
+                c_compiler=bs_dict.get("c_compiler", ""),
+                cxx_compiler=bs_dict.get("cxx_compiler", ""),
+            )
+            node_data = NodeData(
+                node_id=nd["node_id"],
+                title=nd["title"],
+                pos_x=nd["pos_x"],
+                pos_y=nd["pos_y"],
+                cmake_options=nd.get("cmake_options", []),
+                project_path=nd.get("project_path", ""),
+                build_settings=bs,
+                code_before_build=nd.get("code_before_build", ""),
+                code_after_install=nd.get("code_after_install", ""),
+            )
             node_item = NodeItem(data=node_data)
             self.addItem(node_item)
             self.nodes.append(node_item)


### PR DESCRIPTION
## Summary
- add `BuildSettings` dataclass and extend `NodeData`
- move build configuration to each node and update serialization
- add inheritance options to node creation dialog
- show/hide node properties dock on selection
- update build workflow to use per-node settings

## Testing
- `python -m py_compile cmake_node_editor/*.py`