### PR TITLE
Add grid opacity & settings dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ CMake Conductor is a user-friendly application designed to simplify the manageme
 - **Streamlined Workflow**: Easily set up and manage custom build steps without dealing with complex command line instructions.
 - **Real-Time Monitoring**: View build progress and logs as your project is built, making it simple to spot and address issues.
 
+The "Settings" option in the **File** menu lets you change the application style and adjust the background grid transparency.
+
 ## How to Use
 1. **Launch the Application**  
    Open your terminal and run:

--- a/cmake_node_editor/node_editor_window.py
+++ b/cmake_node_editor/node_editor_window.py
@@ -5,7 +5,7 @@ from multiprocessing import Queue
 from PyQt6.QtCore import Qt, QThread, pyqtSignal
 from PyQt6.QtGui import QPainter, QWheelEvent, QPainter, QMouseEvent
 from PyQt6.QtWidgets import (
-    QMainWindow, QDockWidget, QWidget, QFormLayout, QVBoxLayout, QHBoxLayout,
+    QApplication, QMainWindow, QDockWidget, QWidget, QFormLayout, QVBoxLayout, QHBoxLayout,
     QPlainTextEdit, QLineEdit, QPushButton, QLabel, QComboBox, QMessageBox,
     QFileDialog, QGraphicsView, QScrollArea, QProgressBar, QInputDialog, QMenu
 )
@@ -16,6 +16,7 @@ from .datas import (
     BuildSettings, SubprocessLogData, SubprocessResponseData
 )
 from .creation_dialog import NodeCreationDialog
+from .settings_dialog import SettingsDialog
 from .worker import worker_main
 
 class ResultListenerThread(QThread):
@@ -283,6 +284,9 @@ class NodeEditorWindow(QMainWindow):
         act_load = file_menu.addAction("Load Project...")
         act_load.triggered.connect(self.onLoadProject)
 
+        act_settings = file_menu.addAction("Settings")
+        act_settings.triggered.connect(self.onSettings)
+
         project_menu = menubar.addMenu("Project")
         act_full = project_menu.addAction("Full Build")
         act_full.triggered.connect(lambda: self.onBuildAll(start_node_name=None, force_first=True))
@@ -349,6 +353,14 @@ class NodeEditorWindow(QMainWindow):
         Restore global build settings from the loaded dict.
         """
         self.edit_start_node_id.setText(global_cfg.get("start_node_id", ""))
+
+    def onSettings(self):
+        current_style = QApplication.style().objectName()
+        dlg = SettingsDialog(current_style, self.scene.gridOpacity(), self)
+        if dlg.exec():
+            style_name, opacity = dlg.getValues()
+            QApplication.setStyle(style_name)
+            self.scene.setGridOpacity(opacity)
 
     def onPartialBuild(self):
         names = [n.title() for n in self.scene.nodes]

--- a/cmake_node_editor/node_scene.py
+++ b/cmake_node_editor/node_scene.py
@@ -3,7 +3,7 @@ import json
 from collections import deque
 
 from PyQt6.QtCore import Qt, QRectF, QPointF, QLineF
-from PyQt6.QtGui import QBrush, QPen, QPainterPath
+from PyQt6.QtGui import QBrush, QPen, QPainterPath, QColor
 from PyQt6.QtWidgets import (
     QGraphicsScene, QGraphicsRectItem, QGraphicsPathItem,
     QGraphicsItem, QGraphicsTextItem
@@ -336,6 +336,7 @@ class NodeScene(QGraphicsScene):
         self.nodes = []
         self.edges = []
         self.topology_changed_callback = None
+        self.grid_opacity = 1.0
 
     def drawBackground(self, painter, rect):
         """Draw a simple grid as the scene background."""
@@ -346,7 +347,9 @@ class NodeScene(QGraphicsScene):
         top = int(rect.top()) - (int(rect.top()) % grid_size)
 
         painter.save()
-        painter.setPen(QPen(Qt.GlobalColor.lightGray, 1))
+        color = QColor(Qt.GlobalColor.lightGray)
+        color.setAlphaF(self.grid_opacity)
+        painter.setPen(QPen(color, 1))
 
         x = left
         while x < rect.right():
@@ -359,6 +362,14 @@ class NodeScene(QGraphicsScene):
             y += grid_size
 
         painter.restore()
+
+    def setGridOpacity(self, value: float):
+        """Set the transparency of the background grid (0.0 - 1.0)."""
+        self.grid_opacity = max(0.0, min(1.0, value))
+        self.update()
+
+    def gridOpacity(self) -> float:
+        return self.grid_opacity
 
     def setTopologyCallback(self, func):
         """

--- a/cmake_node_editor/settings_dialog.py
+++ b/cmake_node_editor/settings_dialog.py
@@ -1,0 +1,37 @@
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (
+    QDialog, QFormLayout, QComboBox, QDoubleSpinBox,
+    QDialogButtonBox, QLabel, QStyleFactory
+)
+
+class SettingsDialog(QDialog):
+    """Dialog for general application settings."""
+
+    def __init__(self, current_style: str, current_opacity: float, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Settings")
+
+        self.style_combo = QComboBox()
+        self.style_combo.addItems(QStyleFactory.keys())
+        idx = self.style_combo.findText(current_style, Qt.MatchFlag.MatchFixedString)
+        if idx >= 0:
+            self.style_combo.setCurrentIndex(idx)
+
+        self.opacity_spin = QDoubleSpinBox()
+        self.opacity_spin.setRange(0.0, 1.0)
+        self.opacity_spin.setSingleStep(0.05)
+        self.opacity_spin.setValue(current_opacity)
+
+        form = QFormLayout(self)
+        form.addRow(QLabel("Application Style:"), self.style_combo)
+        form.addRow(QLabel("Grid Opacity:"), self.opacity_spin)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok |
+                                   QDialogButtonBox.StandardButton.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        form.addWidget(buttons)
+
+    def getValues(self):
+        """Return the chosen style name and grid opacity."""
+        return self.style_combo.currentText(), self.opacity_spin.value()


### PR DESCRIPTION
## Summary
- allow customizing grid opacity in NodeScene
- support app style and grid opacity via new Settings dialog
- expose Settings under File menu
- document new Settings option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`