### PR TITLE
Improve inheritance options and build failure handling

### DIFF
--- a/cmake_node_editor/node_editor_window.py
+++ b/cmake_node_editor/node_editor_window.py
@@ -371,22 +371,29 @@ class NodeEditorWindow(QMainWindow):
     def onAddNodeDialog(self):
         dlg = NodeCreationDialog(self, existing_nodes=self.scene.nodes)
         if dlg.exec() == dlg.DialogCode.Accepted:
-            node_name, opts, proj_path, inherit_idx, flags = dlg.getNodeData()
+            node_name, opts, proj_path, inherit_idx, attrs = dlg.getNodeData()
             if inherit_idx >= 0 and inherit_idx < len(self.scene.nodes):
                 base_node = self.scene.nodes[inherit_idx]
             else:
                 base_node = None
             if base_node:
-                if flags.get("project"):
+                bs = None
+                code_before = ""
+                code_after = ""
+                if "project_path" in attrs:
                     proj_path = base_node.projectPath()
-                if flags.get("options"):
+                if "cmake_options" in attrs:
                     opts = list(base_node.cmakeOptions())
-                if flags.get("build"):
+                if "build_settings" in attrs:
                     bs = base_node.buildSettings()
-                else:
-                    bs = None
+                if "code_before_build" in attrs:
+                    code_before = base_node.codeBeforeBuild()
+                if "code_after_install" in attrs:
+                    code_after = base_node.codeAfterInstall()
             else:
                 bs = None
+                code_before = ""
+                code_after = ""
 
             if not node_name:
                 node_name = f"Node_{self.scene.nodeCounter}"
@@ -394,6 +401,10 @@ class NodeEditorWindow(QMainWindow):
                 QMessageBox.warning(self, "Warning", f"Node name '{node_name}' already exists.")
                 return
             new_node = self.scene.addNewNode(node_name, opts, proj_path, bs)
+            if code_before:
+                new_node.setCodeBeforeBuild(code_before)
+            if code_after:
+                new_node.setCodeAfterInstall(code_after)
             self.scene.clearSelection()
             new_node.setSelected(True)
 

--- a/cmake_node_editor/worker.py
+++ b/cmake_node_editor/worker.py
@@ -150,7 +150,9 @@ def worker_main(task_queue: Queue, result_queue: Queue):
                     if build_failed:
                         break
 
-                if not build_failed:
+                if build_failed:
+                    result_queue.put(SubprocessResponseData(index=-1, result=False))
+                else:
                     result_queue.put(SubprocessLogData(index=-1, log="[Worker] All commands succeeded!"))
                     result_queue.put(SubprocessResponseData(index=-1, result=True))
 


### PR DESCRIPTION
## Summary
- dynamically list available node attributes when creating a node
- allow multi-select of attributes to inherit
- apply selected attributes when adding new node
- send final failure signal from worker so UI resets correctly

## Testing
- `python -m py_compile cmake_node_editor/*.py`