### PR TITLE
Make package executable via `python -m cmake_node_editor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ The "Settings" option in the **File** menu lets you change the application style
 1. **Launch the Application**  
    Open your terminal and run:
    ```bash
-   python -m cmake_node_editor.main
+   python -m cmake_node_editor

--- a/cmake_node_editor/__init__.py
+++ b/cmake_node_editor/__init__.py
@@ -1,2 +1,7 @@
-# __init__.py
+"""CMake Conductor package initialization."""
+
 __version__ = "0.1.0"
+
+from .main import main
+
+__all__ = ["main"]

--- a/cmake_node_editor/__main__.py
+++ b/cmake_node_editor/__main__.py
@@ -1,0 +1,4 @@
+from .main import main
+
+if __name__ == "__main__":
+    main()

--- a/cmake_node_editor/node_editor_window.py
+++ b/cmake_node_editor/node_editor_window.py
@@ -3,7 +3,7 @@ import multiprocessing
 from multiprocessing import Queue
 
 from PyQt6.QtCore import Qt, QThread, pyqtSignal
-from PyQt6.QtGui import QPainter, QWheelEvent, QPainter, QMouseEvent
+from PyQt6.QtGui import QPainter, QWheelEvent, QMouseEvent
 from PyQt6.QtWidgets import (
     QApplication, QMainWindow, QDockWidget, QWidget, QFormLayout, QVBoxLayout, QHBoxLayout,
     QPlainTextEdit, QLineEdit, QPushButton, QLabel, QComboBox, QMessageBox,


### PR DESCRIPTION
## Summary
- add `__main__` so the package can run with `python -m cmake_node_editor`
- expose `main()` from package `__init__`
- remove duplicate import in `node_editor_window.py`
- update README usage instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m cmake_node_editor` *(fails: ModuleNotFoundError: No module named 'PyQt6')*
- `pip install PyQt6` *(fails: Could not find a version that satisfies the requirement PyQt6)*