### PR TITLE
Support node ID ranges for partial builds

### DIFF
--- a/cmake_node_editor/datas.py
+++ b/cmake_node_editor/datas.py
@@ -47,6 +47,7 @@ class NodeCommands:
 @dataclass
 class ProjectCommands:
     start_node_id: int
+    end_node_id: int = -1
     node_commands_list: list[NodeCommands] = field(default_factory=list)
 
 @dataclass


### PR DESCRIPTION
## Summary
- allow specifying a node id range for partial actions
- store end node id in `ProjectCommands`
- adapt context menus and internal logic to work with id ranges

## Testing
- `python -m py_compile $(git ls-files '*.py')`