### PR TITLE
Support node ID range for partial builds

### DIFF
--- a/cmake_node_editor/datas.py
+++ b/cmake_node_editor/datas.py
@@ -47,6 +47,7 @@ class NodeCommands:
 @dataclass
 class ProjectCommands:
     start_node_id: int
+    end_node_id: int = -1
     node_commands_list: list[NodeCommands] = field(default_factory=list)
 
 @dataclass

--- a/cmake_node_editor/node_editor_window.py
+++ b/cmake_node_editor/node_editor_window.py
@@ -2,13 +2,13 @@ import os
 import multiprocessing
 from multiprocessing import Queue
 
-from PyQt6.QtCore import Qt, QThread, pyqtSignal
-from PyQt6.QtGui import QPainter, QWheelEvent, QMouseEvent
+from PyQt6.QtCore import Qt, QThread, pyqtSignal, QUrl
+from PyQt6.QtGui import QPainter, QWheelEvent, QMouseEvent, QDesktopServices
 from PyQt6.QtWidgets import (
     QApplication, QMainWindow, QDockWidget, QWidget, QFormLayout, QVBoxLayout, QHBoxLayout,
     QPlainTextEdit, QLineEdit, QPushButton, QLabel, QComboBox, QMessageBox,
-    QFileDialog, QGraphicsView, QScrollArea, QProgressBar, QInputDialog, QMenu,
-    QListWidget, QListWidgetItem
+    QFileDialog, QGraphicsView, QScrollArea, QProgressBar, QMenu,
+    QListWidget, QListWidgetItem, QSpinBox, QDialog, QDialogButtonBox
 )
 
 from .node_scene import NodeScene, NodeItem, Edge
@@ -125,6 +125,8 @@ class NodeView(QGraphicsView):
             act_build_from = menu.addAction("Build From This")
             act_install_from = menu.addAction("Install From This")
             menu.addSeparator()
+            act_open_dir = menu.addAction("Open Project Directory")
+            menu.addSeparator()
             act_prop = menu.addAction("Properties")
             action = menu.exec(global_pos)
             parent = self.parent()
@@ -132,19 +134,25 @@ class NodeView(QGraphicsView):
                 return
             if action == act_prop and hasattr(parent, 'openNodePropertyDialog'):
                 parent.openNodePropertyDialog(item)
+            elif action == act_open_dir:
+                proj_dir = item.projectPath()
+                if proj_dir and os.path.isdir(proj_dir):
+                    QDesktopServices.openUrl(QUrl.fromLocalFile(os.path.abspath(proj_dir)))
+                else:
+                    QMessageBox.warning(self, "Warning", "Invalid project directory")
             elif hasattr(parent, 'runStage'):
                 if action == act_cfg_node:
-                    parent.runStage(stage="configure", start_node_name=item.title(), only_first=True)
+                    parent.runStage(stage="configure", start_node_id=item.id(), only_first=True)
                 elif action == act_build_node:
-                    parent.runStage(stage="build", start_node_name=item.title(), only_first=True)
+                    parent.runStage(stage="build", start_node_id=item.id(), only_first=True)
                 elif action == act_install_node:
-                    parent.runStage(stage="install", start_node_name=item.title(), only_first=True)
+                    parent.runStage(stage="install", start_node_id=item.id(), only_first=True)
                 elif action == act_cfg_from:
-                    parent.runStage(stage="configure", start_node_name=item.title())
+                    parent.runStage(stage="configure", start_node_id=item.id())
                 elif action == act_build_from:
-                    parent.runStage(stage="build", start_node_name=item.title())
+                    parent.runStage(stage="build", start_node_id=item.id())
                 elif action == act_install_from:
-                    parent.runStage(stage="install", start_node_name=item.title())
+                    parent.runStage(stage="install", start_node_id=item.id())
         else:
             act_new = menu.addAction("Create Node")
             action = menu.exec(global_pos)
@@ -162,6 +170,37 @@ class NodeView(QGraphicsView):
             event.accept()
         else:
             super().keyPressEvent(event)
+
+
+class NodeRangeDialog(QDialog):
+    """Dialog to input a start and end node ID."""
+
+    def __init__(self, min_id: int, max_id: int, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Select Node ID Range")
+        layout = QVBoxLayout(self)
+
+        form = QFormLayout()
+        self.start_spin = QSpinBox()
+        self.start_spin.setRange(min_id, max_id)
+        self.start_spin.setValue(min_id)
+        self.end_spin = QSpinBox()
+        self.end_spin.setRange(min_id, max_id)
+        self.end_spin.setValue(max_id)
+        form.addRow("Start ID:", self.start_spin)
+        form.addRow("End ID:", self.end_spin)
+        layout.addLayout(form)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel,
+            parent=self,
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def getValues(self):
+        return self.start_spin.value(), self.end_spin.value()
 
 class NodeEditorWindow(QMainWindow):
     """
@@ -353,13 +392,24 @@ class NodeEditorWindow(QMainWindow):
             self.scene.setLinkColor(link_color)
 
     def onPartialStage(self, stage: str):
-        names = [n.title() for n in self.scene.nodes]
-        if not names:
+        sorted_nodes = self.scene.topologicalSort()
+        if not sorted_nodes:
             QMessageBox.information(self, "Info", "No nodes available")
             return
-        name, ok = QInputDialog.getItem(self, f"Partial {stage.title()}", "Start from node:", names, 0, False)
-        if ok and name:
-            self.runStage(stage=stage, start_node_name=name)
+        dlg = NodeRangeDialog(sorted_nodes[0].id(), sorted_nodes[-1].id(), self)
+        if dlg.exec() == QDialog.DialogCode.Accepted:
+            s_id, e_id = dlg.getValues()
+            ids = [n.id() for n in sorted_nodes]
+            if s_id not in ids:
+                QMessageBox.warning(self, "Warning", f"Start ID {s_id} not found.")
+                return
+            if e_id not in ids:
+                QMessageBox.warning(self, "Warning", f"End ID {e_id} not found.")
+                return
+            if ids.index(e_id) < ids.index(s_id):
+                QMessageBox.warning(self, "Warning", "Invalid node range.")
+                return
+            self.runStage(stage=stage, start_node_id=s_id, end_node_id=e_id)
 
     # ----------------------------------------------------------------
     # Node operations
@@ -454,10 +504,23 @@ class NodeEditorWindow(QMainWindow):
     # ----------------------------------------------------------------
     # Asynchronous build flow
     # ----------------------------------------------------------------
-    def runStage(self, stage="build", start_node_name=None, force_first=False, only_first=False):
+    def runStage(self, stage="build", start_node_id=None, end_node_id=None, force_first=False, only_first=False):
         """
         Build ProjectCommands for the given stage (configure/build/install) and
         execute them in a worker process.
+
+        Parameters
+        ----------
+        stage : str
+            Build stage (configure/build/install/all)
+        start_node_id : int | None
+            ID of the first node to run. If None, start from the beginning.
+        end_node_id : int | None
+            ID of the last node to run. If None, run until the end.
+        force_first : bool
+            If True, ignore start_node_id and always begin from the first node.
+        only_first : bool
+            If True, run only the first node in the range.
         """
         self.build_output_text.clear()
 
@@ -471,22 +534,40 @@ class NodeEditorWindow(QMainWindow):
         start_index = 0
         if force_first:
             start_id = sorted_nodes[0].id() if sorted_nodes else -1
-        elif start_node_name:
+        elif start_node_id is not None:
             for idx, node_item in enumerate(sorted_nodes):
-                if node_item.title() == start_node_name:
-                    start_id = node_item.id()
+                if node_item.id() == start_node_id:
+                    start_id = start_node_id
                     start_index = idx
                     break
             if start_id is None:
-                QMessageBox.warning(self, "Warning", f"Node '{start_node_name}' not found, building from beginning.")
+                QMessageBox.warning(self, "Warning", f"Start node ID {start_node_id} not found.")
+                return
+
+        end_index = len(sorted_nodes)
+        if end_node_id is not None:
+            found_end = False
+            for idx, node_item in enumerate(sorted_nodes):
+                if node_item.id() == end_node_id:
+                    end_index = idx + 1
+                    found_end = True
+                    break
+            if not found_end:
+                QMessageBox.warning(self, "Warning", f"End node ID {end_node_id} not found.")
+                return
+
+        if end_index <= start_index:
+            QMessageBox.warning(self, "Warning", "Invalid node range specified.")
+            return
 
         project_commands = ProjectCommands(
             start_node_id=start_id if start_id is not None else -1,
+            end_node_id=sorted_nodes[end_index-1].id() if end_index > 0 else -1,
             node_commands_list=[]
         )
 
-        # For each node in sorted order, build NodeCommands & CommandData
-        for node_obj in sorted_nodes[start_index:]:
+        # For each node in sorted order within the specified range, build NodeCommands & CommandData
+        for node_obj in sorted_nodes[start_index:end_index]:
             node_cmd = NodeCommands(index=node_obj.id(), node_data=node_obj.nodeData(), cmd_list=[])
 
             bs = node_obj.buildSettings()


### PR DESCRIPTION
## Summary
- allow specifying a node id range for partial actions
- store end node id in `ProjectCommands`
- adapt context menus and internal logic to work with id ranges
- add 'open project directory' context menu entry

## Testing
- `python -m py_compile $(git ls-files '*.py')`
