### PR TITLE
Fix panning mode stuck after node creation

### DIFF
--- a/cmake_node_editor/node_editor_window.py
+++ b/cmake_node_editor/node_editor_window.py
@@ -111,6 +111,12 @@ class NodeView(QGraphicsView):
             super(NodeView, self).mouseReleaseEvent(event)
 
     def showContextMenu(self, pos):
+        # On some platforms the customContextMenuRequested signal may be emitted
+        # before the mouse release event. In that case ``_panning`` will remain
+        # True and the view stays in grab mode after closing the context menu.
+        # Reset the panning state here to ensure the cursor is restored.
+        self._panning = False
+        self.setCursor(Qt.CursorShape.ArrowCursor)
         self.openContextMenu(self.mapToGlobal(pos), pos)
 
     def openContextMenu(self, global_pos, view_pos):


### PR DESCRIPTION
## Summary
- avoid leaving the view in grab mode when the context menu opens before mouse release

## Testing
- `python -m py_compile cmake_node_editor/node_editor_window.py`
- `python -m py_compile cmake_node_editor/*.py`
